### PR TITLE
added fight id to WarcraftLogs link for that particular boss.

### DIFF
--- a/server.js
+++ b/server.js
@@ -196,7 +196,7 @@ function sortParsedData(data) {
 
     for(var p = 0; p < logData.length; p++) {
       if (currentBoss.bossId === logData[p].encounter && difficulty === logData[p].difficulty) {
-        var reportUrl = "https://www.warcraftlogs.com/reports/" + logData[p].reportID;
+        var reportUrl = "https://www.warcraftlogs.com/reports/" + logData[p].reportID + "#fight=" + logData[p].fightID;
         currentBoss.warcraftLogs = true;
         currentBoss.reportUrl = reportUrl;
       }


### PR DESCRIPTION
It should be expected that when clicking a log link in line with a boss, that it will bring you to that exact boss fight in the log provided. Resolves #3 