### PR TITLE
Replace Switch Statements with Cleaner Lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@ A clean and simple World of Warcraft character look up displaying their current 
 
 # Feature Requests
 Is there a feature that you feel would be a worthwhile addition to PugCheck? Go to the Issues tab above, click the green New Issue button on the top right and be sure to Label the Issue as an Enhancement.
+
+# Running Tests
+Pug-check uses Mocha to run the unit tests. Use the following commands to run them:
+
+1. Clone the repo (if you haven't already)
+2. Run `npm install` to install dependencies
+3. Run `npm test` to run the tests.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A simple character progression lookup tool for raid leaders and recruitment officers in World of Warcraft guilds and raid teams.",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "mocha --recursive test"
   },
   "keywords": [
     "warcraft"
@@ -15,6 +16,11 @@
     "body-parser": "^1.15.2",
     "ejs": "^2.5.1",
     "express": "^4.14.0",
+    "lodash": "^4.16.3",
     "request": "^2.74.0"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warcarft-character-progress",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple character progression lookup tool for raid leaders and recruitment officers in World of Warcraft guilds and raid teams.",
   "main": "server.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -1,6 +1,9 @@
 const https = require('https');
 const express = require('express');
 const app = express();
+const lookups = require('./utils/lookups');
+const lookupClassName = lookups.lookupClassName;
+const lookupBossId = lookups.lookupBossId;
 
 var port = process.env.PORT || 8080
 
@@ -90,65 +93,12 @@ function htmlEncode(characterName) {
   return encoded.join('');
 }
 
-// determining character's class based on class id sent from the API
-function classIdentity(classId) {
-  switch (classId) {
-    case 1:
-      return "warrior"
-    case 2:
-      return "paladin"
-    case 3:
-      return "hunter"
-    case 4:
-      return "rogue"
-    case 5:
-      return "priest"
-    case 6:
-      return "death-knight"
-    case 7:
-      return "shaman"
-    case 8:
-      return "mage"
-    case 9:
-      return "warlock"
-    case 10:
-      return "monk"
-    case 11:
-      return "druid"
-    case 12:
-      return "demon-hunter"
-    default:
-      return null
-  }
-}
-
-// determine raid boss ID based on WarcraftLogs seperate ID
-function wclBossId(bossId) {
-  // Emerald Nightmare Boss Id's
-  switch(bossId) {
-    case "Nythendra":
-      return 1853
-    case "Il'gynoth, Heart of Corruption":
-      return 1873
-    case "Elerethe Renferal":
-      return 1876
-    case "Ursoc":
-      return 1841
-    case "Dragons of Nightmare":
-      return 1854
-    case "Cenarius":
-      return 1877
-    case "Xavius":
-      return 1864
-  }
-}
-
 // overall sorting and filtering of data
 function sortParsedData(data) {
   // sorting out character info and progress info
   var sortData = {
     name: data[0].name,
-    class: classIdentity(data[0].class),
+    class: lookupClassId(data[0].class),
     realm: data[0].realm,
     itemLevel: data[0].items.averageItemLevel,
     progress: data[0].progression.raids
@@ -163,7 +113,7 @@ function sortParsedData(data) {
           bosses: item.bosses.map((item, index) => {
             return {
               name: item.name,
-              bossId: wclBossId(item.name),
+              bossId: lookupBossId(item.name),
               lfrKills: item.lfrKills,
               normalKills: item.normalKills,
               heroicKills: item.heroicKills,

--- a/test/utils/lookups.js
+++ b/test/utils/lookups.js
@@ -1,0 +1,109 @@
+const expect = require('chai').expect;
+const lookups = require('../../utils/lookups');
+
+const originalClassLookup = function classIdentity(classId) {
+  switch (classId) {
+    case 1:
+      return "warrior"
+    case 2:
+      return "paladin"
+    case 3:
+      return "hunter"
+    case 4:
+      return "rogue"
+    case 5:
+      return "priest"
+    case 6:
+      return "death-knight"
+    case 7:
+      return "shaman"
+    case 8:
+      return "mage"
+    case 9:
+      return "warlock"
+    case 10:
+      return "monk"
+    case 11:
+      return "druid"
+    case 12:
+      return "demon-hunter"
+    default:
+      return null
+  }
+};
+
+const originalBossLookup = function wclBossId(bossId) {
+  // Emerald Nightmare Boss Id's
+  switch(bossId) {
+    case "Nythendra":
+      return 1853
+    case "Il'gynoth, Heart of Corruption":
+      return 1873
+    case "Elerethe Renferal":
+      return 1876
+    case "Ursoc":
+      return 1841
+    case "Dragons of Nightmare":
+      return 1854
+    case "Cenarius":
+      return 1877
+    case "Xavius":
+      return 1864
+  }
+};
+
+
+describe('lookups', () => {
+  describe('class lookups', () => {
+    describe('name lookup', () => {
+      it('should do the same thing as the original lookup did', () => {
+        for(var i = 1; i <= 12; i++){
+          const originalLookup = originalClassLookup(i);
+          const newLookup = lookups.lookupClassName(i);
+          expect(originalLookup).to.equal(newLookup);
+        }
+      });
+
+      it('should lookup a class name by its id', () => {
+        expect(lookups.lookupClassName(1)).to.equal('warrior');
+      });
+    });
+
+    describe('id lookup', () => {
+      it('should lookup the class id by name', () => {
+        expect(lookups.lookupClassId('warrior')).to.equal(1);
+      });
+    });
+  });
+
+  describe('boss lookups', () => {
+    describe('id lookup', () => {
+      it('should do the same thing as the original lookup did', () => {
+        const bossNames = [
+          "Nythendra",
+          "Il'gynoth, Heart of Corruption",
+          "Elerethe Renferal",
+          "Ursoc",
+          "Dragons of Nightmare",
+          "Cenarius",
+          "Xavius"
+        ];
+        bossNames.forEach(bossName => {
+          const originalLookup = originalBossLookup(bossName);
+          const newLookup = lookups.lookupBossId(bossName);
+          expect(originalLookup).to.equal(newLookup);
+        })
+      });
+
+      it('should lookup the boss id based on the name', () => {
+        expect(lookups.lookupBossId('Nythendra')).to.equal(1853);
+      });
+    });
+
+    describe('name lookup', () => {
+      it('should lookup the boss name based on the id', () => {
+        expect(lookups.lookupBossName(1853)).to.equal('Nythendra');
+      });
+    });
+  });
+});

--- a/utils/lookups.js
+++ b/utils/lookups.js
@@ -1,0 +1,53 @@
+const _ = require('lodash');
+
+const classMap = {
+  1: "warrior",
+  2: "paladin",
+  3: "hunter",
+  4: "rogue",
+  5: "priest",
+  6: "death-knight",
+  7: "shaman",
+  8: "mage",
+  9: "warlock",
+  10: "monk",
+  11: "druid",
+  12: "demon-hunter"
+};
+
+const lookupClassName = classId => {
+  return classMap[classId];
+}
+
+const lookupClassId = className => {
+  const classIdString = _.invert(classMap)[className];
+  return parseInt(classIdString, 10);
+};
+
+
+const bossMap = {
+  "Nythendra": 1853,
+  "Il'gynoth, Heart of Corruption": 1873,
+  "Elerethe Renferal": 1876,
+  "Ursoc": 1841,
+  "Dragons of Nightmare": 1854,
+  "Cenarius": 1877,
+  "Xavius": 1864
+};
+
+const lookupBossId = bossName => {
+  return bossMap[bossName];
+};
+
+const lookupBossName = bossId => {
+  return _.invert(bossMap)[bossId];
+}
+
+module.exports = {
+  classMap,
+  lookupClassId,
+  lookupClassName,
+  bossMap,
+  lookupBossName,
+  lookupBossId
+};


### PR DESCRIPTION
Main functionality:
 * Replaced some larger switch statements with smaller lookup functions
 * Moved the lookup functions to their own module

Secondary Functionality:
 * Added unit tests for the new lookups
 * Add mocha/chai to be able to run the tests for the new lookups
 * Added lodash because its crazy useful

Closes: #5 