### PR TITLE
Removed unecessary loop & two small design changes.

### DIFF
--- a/server.js
+++ b/server.js
@@ -121,7 +121,7 @@ function sortParsedData(data) {
               warcraftLogs: false
             }
           }),
-          totalBosses: bossTotal(item.bosses),
+          totalBosses: item.bosses.length,
           lfrProgress: difficultyProgress("lfr", item),
           normalProgress: difficultyProgress("normal", item),
           heroicProgress: difficultyProgress("heroic", item),
@@ -159,12 +159,6 @@ function sortParsedData(data) {
 
   console.log('Request made for', sortData.name, "on the realm", sortData.realm);
   return sortData;
-}
-
-// Obtains total bosses in an instance
-function bossTotal(bossData) {
-
-  return bossData.length;
 }
 
 // Obtains bosses killed for a given raid difficulty

--- a/server.js
+++ b/server.js
@@ -163,13 +163,8 @@ function sortParsedData(data) {
 
 // Obtains total bosses in an instance
 function bossTotal(bossData) {
-  var bossCount = 0;
 
-  for(var b = 0; b < bossData.length; b++) {
-    bossCount++;
-  }
-
-  return bossCount;
+  return bossData.length;
 }
 
 // Obtains bosses killed for a given raid difficulty

--- a/views/character-info.ejs
+++ b/views/character-info.ejs
@@ -50,11 +50,10 @@
       <div class="raid-instance">
         <div class="raid-instance-title">
           <span class="collapse fa fa-plus"></span>
-          <h5 class="instance-name"><%= info.progress[0].name %> (<%= progress[i] %>/<%= info.progress[0].totalBosses %>)</h5>
-          <p class="difficulty"><%= difficulty[i] %></p>
+          <h5 class="instance-name"><%= info.progress[0].name %></h5>
+          <p class="difficulty"><%= progress[i] %>/<%= info.progress[0].totalBosses %> <%= difficulty[i] %></p>
           <p class="logs-header">
             Logs
-            <span class="fa fa-link"></span>
           </p>
         </div>
         <ul class="raid-bosses hidden">


### PR DESCRIPTION
The bossTotal function was not necessary and has been removed. 

The link icon next to the `Logs` header was confusing users and giving the impression that the header was a link to logs and has been removed.

On mobile devices with smaller widths, the `Logs` header was running agains the progression numbers. The numbers were moved next to the difficulty indicator. This makes it easier to read and also fixes the messy look on these devices.